### PR TITLE
Making python3 explicit.

### DIFF
--- a/cfg/asv_sim.cfg
+++ b/cfg/asv_sim.cfg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 PACKAGE = "asv_sim"
 
 from dynamic_reconfigure.parameter_generator_catkin import *

--- a/nodes/asv_sim_node.py
+++ b/nodes/asv_sim_node.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Roland Arsenault
 # Center for Coastal and Ocean Mapping
 # University of New Hampshire
 # Copyright 2017, All rights reserved.
 
-from builtins import object
 import math
 import time
 import threading

--- a/src/asv_sim/coastal_surveyor.py
+++ b/src/asv_sim/coastal_surveyor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Roland Arsenault
 # Center for Coastal and Ocean Mapping

--- a/src/asv_sim/cw4.py
+++ b/src/asv_sim/cw4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Roland Arsenault and Val Schmidt
 # Center for Coastal and Ocean Mapping

--- a/src/asv_sim/dynamics.py
+++ b/src/asv_sim/dynamics.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Roland Arsenault
 # Center for Coastal and Ocean Mapping
 # University of New Hampshire
 # Copyright 2017, All rights reserved.
 
-from __future__ import absolute_import
-from builtins import object
 import math
 import random
 from . import geodesic

--- a/src/asv_sim/environment.py
+++ b/src/asv_sim/environment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Roland Arsenault
 # Center for Coastal and Ocean Mapping
@@ -6,7 +6,6 @@
 # Copyright 2017, All rights reserved.
 
 
-from builtins import object
 class Environment(object):
     def __init__(self):
         self.current = {"speed": 1.0, "direction": 90.0}

--- a/src/asv_sim/geodesic.py
+++ b/src/asv_sim/geodesic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 __author__    = 'Roland Arsenault'
 


### PR DESCRIPTION
Making python3 explicit in shebang and removing `from __future__` and `from builtins` imports from `.py` files.

The reasons for this are...

1. For our use-case we are using ROS-Noetic (Python 3) with older code that is Python 2, so need to be explicit with the interpreter. 
2. Noetic is exclusively Python 3, so including the imports can be confusing.